### PR TITLE
ISSUE-5 Add Cognito auth to endpoints

### DIFF
--- a/deployment/terraform/auth.tf
+++ b/deployment/terraform/auth.tf
@@ -1,0 +1,14 @@
+
+resource "aws_api_gateway_authorizer" "propertyservice_api_authorizer" {
+  name          = "propertyservice-authorizer"
+  rest_api_id   = aws_api_gateway_rest_api.propertyservice_api.id
+  type          = "COGNITO_USER_POOLS"
+  provider_arns = concat(tolist(data.aws_cognito_user_pools.propertyservice_userpool.arns), tolist(data.aws_cognito_user_pools.propertyservice_admin_userpool.arns))
+}
+
+resource "aws_api_gateway_authorizer" "propertyservice_api_admin_authorizer" {
+  name          = "propertyservice-admin-authorizer"
+  rest_api_id   = aws_api_gateway_rest_api.propertyservice_api.id
+  type          = "COGNITO_USER_POOLS"
+  provider_arns = data.aws_cognito_user_pools.propertyservice_admin_userpool.arns
+}

--- a/deployment/terraform/datasources.tf
+++ b/deployment/terraform/datasources.tf
@@ -1,0 +1,7 @@
+data "aws_cognito_user_pools" "propertyservice_userpool" {
+  name = format("revlet-%s-userpool", var.ENVIRONMENT)
+}
+
+data "aws_cognito_user_pools" "propertyservice_admin_userpool" {
+  name = format("revlet-%s-admin-userpool", var.ENVIRONMENT)
+}

--- a/deployment/terraform/dynamodb.tf
+++ b/deployment/terraform/dynamodb.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "propertyservice_table" {
-  name           = "revlet-properties"
+  name           = format("revlet-%s-properties", var.ENVIRONMENT)
   billing_mode   = "PROVISIONED"
   read_capacity  = 20
   write_capacity = 20
@@ -11,7 +11,7 @@ resource "aws_dynamodb_table" "propertyservice_table" {
   }
 
   tags = {
-    env     = "dev"
+    env     = var.ENVIRONMENT
     service = "propertyservice"
   }
 }

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -23,7 +23,7 @@ resource "aws_iam_role" "propertyservice_role" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_policy" {
-  name = "propertyservice_policy"
+  name = "propertyservice-policy"
   role = aws_iam_role.propertyservice_role.id
 
   policy = jsonencode({

--- a/deployment/terraform/lambda.tf
+++ b/deployment/terraform/lambda.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_lambda_function" "propertyservice_lambda" {
   for_each      = toset(local.propertyservice_handlers)
-  function_name = format("propertyservice_%s", each.key)
+  function_name = format("propertyservice-%s-%s", var.ENVIRONMENT, each.key)
   role          = aws_iam_role.propertyservice_role.arn
   package_type  = "Image"
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "IMAGE_TAG" {
   type    = string
   default = "latest"
 }
+
+variable "ENVIRONMENT" {
+  type    = string
+  default = "dev"
+}


### PR DESCRIPTION
Closes #5 

Authenticate added to endpoints using Cognito authorizers which can be tested using ID tokens of test users. 

Tests still successful as authentication is handled on the API and not the functions.

Additional user information will be accessible from the the context object in the lambda request